### PR TITLE
added hardcoded tests to test_translator

### DIFF
--- a/test/unit/test_translator.py
+++ b/test/unit/test_translator.py
@@ -1,13 +1,109 @@
 from src.translator import translate_content
 
-
+# Chinese
 def test_chinese():
     is_english, translated_content = translate_content("这是一条中文消息")
     assert is_english == False
     assert translated_content == "This is a Chinese message"
 
-def test_llm_normal_response():
-    pass
+# French
+def test_french():
+    is_english, translated_content = translate_content("Ceci est un message en français")
+    assert is_english == False
+    assert translated_content == "This is a French message"
 
+# Spanish
+def test_spanish():
+    is_english, translated_content = translate_content("Esta es un mensaje en español")
+    assert is_english == False
+    assert translated_content == "This is a Spanish message"
+
+# Portuguese
+def test_portuguese():
+    is_english, translated_content = translate_content("Esta é uma mensagem em português")
+    assert is_english == False
+    assert translated_content == "This is a Portuguese message"
+
+# Japanese
+def test_japanese():
+    is_english, translated_content = translate_content("これは日本語のメッセージです")
+    assert is_english == False
+    assert translated_content == "This is a Japanese message"
+
+# Korean
+def test_korean():
+    is_english, translated_content = translate_content("이것은 한국어 메시지입니다")
+    assert is_english == False
+    assert translated_content == "This is a Korean message"
+
+# German
+def test_german():
+    is_english, translated_content = translate_content("Dies ist eine Nachricht auf Deutsch")
+    assert is_english == False
+    assert translated_content == "This is a German message"
+
+# Italian
+def test_italian():
+    is_english, translated_content = translate_content("Questo è un messaggio in italiano")
+    assert is_english == False
+    assert translated_content == "This is an Italian message"
+
+# Russian
+def test_russian():
+    is_english, translated_content = translate_content("Это сообщение на русском")
+    assert is_english == False
+    assert translated_content == "This is a Russian message"
+
+# Arabic
+def test_arabic():
+    is_english, translated_content = translate_content("هذه رسالة باللغة العربية")
+    assert is_english == False
+    assert translated_content == "This is an Arabic message"
+
+# Hindi
+def test_hindi():
+    is_english, translated_content = translate_content("यह हिंदी में संदेश है")
+    assert is_english == False
+    assert translated_content == "This is a Hindi message"
+
+# Thai
+def test_thai():
+    is_english, translated_content = translate_content("นี่คือข้อความภาษาไทย")
+    assert is_english == False
+    assert translated_content == "This is a Thai message"
+
+# Turkish
+def test_turkish():
+    is_english, translated_content = translate_content("Bu bir Türkçe mesajdır")
+    assert is_english == False
+    assert translated_content == "This is a Turkish message"
+
+# Vietnamese
+def test_vietnamese():
+    is_english, translated_content = translate_content("Đây là một tin nhắn bằng tiếng Việt")
+    assert is_english == False
+    assert translated_content == "This is a Vietnamese message"
+
+# Catalan
+def test_catalan():
+    is_english, translated_content = translate_content("Esto es un mensaje en catalán")
+    assert is_english == False
+    assert translated_content == "This is a Catalan message"
+
+# English
+def test_english():
+    is_english, translated_content = translate_content("This is an English message")
+    assert is_english == True
+    assert translated_content == "This is an English message"
+
+# ! TODO: LLM normal response
+def test_llm_normal_response():
+    is_english, translated_content = translate_content("This is an english message.")
+    assert is_english == True
+    assert translated_content == "This is an english message."
+
+# ! TODO: LLM gibberish response
 def test_llm_gibberish_response():
-    pass
+    is_english, translated_content = translate_content("asdkjhasd lkjhasd!!!")
+    assert is_english == True
+    assert translated_content == "asdkjhasd lkjhasd!!!"


### PR DESCRIPTION
This pull request adds a suite of hardcoded unit tests to the test_translator.py file located in the test/unit directory. 

The purpose of these tests is to validate the behavior of the translate_content function from the src.translator module. Each test checks the function's ability to correctly handle a non-English input string by verifying two outputs: (1) whether the is_english flag is set to False, and (2) whether the translated content matches a predetermined English phrase that corresponds to the input language. The test suite includes inputs written in Chinese, French, Spanish, Portuguese, Japanese, Korean, German, Italian, Russian, and Arabic. For each language, the function is expected to return a standardized English message in the format “This is a [Language] message.” These tests are purely functional and rely on hardcoded inputs and expected outputs, without the use of mocks or external translation services. This PR ensures the translation logic handles multiple language inputs consistently and is ready for further testing or refinement.