### PR TITLE
Integrating LLM into translator service

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 Flask==3.0.0
 pytest==7.4.0
+openai==1.70.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 Flask==3.0.0
 pytest==7.4.0
-openai==1.70.0
+openai
+sentence-transformers

--- a/src/translator.py
+++ b/src/translator.py
@@ -30,7 +30,7 @@ def get_language(post: str) -> str:
               "Given text: Hier ist dein erstes Beispiel.\n"\
               "German\n"\
               "If it is gibberish, return 'English'\n"\
-            #   "If it cannot be translated, return --ERROR--\n" # Insert context
+ 
     response = client.chat.completions.create(
       model="gpt-4o-mini",  # model name
       messages=[

--- a/src/translator.py
+++ b/src/translator.py
@@ -2,7 +2,7 @@ import openai
 import os
 
 client = openai.OpenAI(
-    api_key=os.getenv(NODEBB_API_KEY)  # Your OpenAI API key
+    api_key=os.getenv("NODEBB_API_KEY")  # Your OpenAI API key
 )
 
 def get_translation(post: str) -> str:

--- a/src/translator.py
+++ b/src/translator.py
@@ -9,7 +9,7 @@ def get_translation(post: str) -> str:
     context = "Provide the English translation of the given text which may or may not be written in English, using the following format.\n"\
               "Given text: Hier ist dein erstes Beispiel.\n"\
               "Here is your first example.\n"\
-              "If you do not understand the text, return the original text\n" # Insert context
+              "If it cannot be translated, return the original text\n" # Insert context
     response = client.chat.completions.create(
       model="gpt-4o-mini",  # model name
       messages=[
@@ -44,17 +44,11 @@ def get_language(post: str) -> str:
           }
         ]
       )
-    print(response.choices[0].message.content.strip())
     return response.choices[0].message.content.strip()
 
 def translate_content(content: str) -> tuple[bool, str]:
     language = get_language(content).strip()
     translation = get_translation(content).strip()
-    # if ("--ERROR--" in language or "--ERROR--" in translation):
-    #     return (False, "--ERROR--")
-    # elif not (language.startswith("language: ") or translation.startswith("Translation: ")):
-    #     return (False, "--ERROR--")
-    print(f"Language: {language}")
     if language != "English":
         return (False, translation)
     return ("English" in language, translation)

--- a/src/translator.py
+++ b/src/translator.py
@@ -1,34 +1,55 @@
+import openai
+import os
+
+client = openai.OpenAI(
+    api_key=os.getenv(NODEBB_API_KEY)  # Your OpenAI API key
+)
+
+def get_translation(post: str) -> str:
+    context = "Provide the English translation of the given text which may or may not be written in English, using the following format.\n"\
+              "Given text: Hier ist dein erstes Beispiel.\n"\
+              "Translation: Here is your first example.\n"\
+              "If you do not understand the text, return --ERROR--\n" # Insert context
+    response = client.chat.completions.create(
+      model="gpt-4o-mini",  # model name
+      messages=[
+          {
+            "role": "system",
+            "content": context
+          },
+          {
+              "role": "user",
+              "content": post
+          }
+        ]
+      )
+    return response.choices[0].message.content.strip()
+
+def get_language(post: str) -> str:
+    context = "Provide in English, only the name of the language the given text is written in, using the following format.\n"\
+              "Given text: Hier ist dein erstes Beispiel.\n"\
+              "Language: German\n"\
+              "If it cannot be translated, return --ERROR--\n" # Insert context
+    response = client.chat.completions.create(
+      model="gpt-4o-mini",  # model name
+      messages=[
+          {
+            "role": "system",
+            "content": context
+          },
+          {
+              "role": "user",
+              "content": post
+          }
+        ]
+      )
+    return response.choices[0].message.content.strip()
+
 def translate_content(content: str) -> tuple[bool, str]:
-    if content == "这是一条中文消息":
-        return False, "This is a Chinese message"
-    if content == "Ceci est un message en français":
-        return False, "This is a French message"
-    if content == "Esta es un mensaje en español":
-        return False, "This is a Spanish message"
-    if content == "Esta é uma mensagem em português":
-        return False, "This is a Portuguese message"
-    if content  == "これは日本語のメッセージです":
-        return False, "This is a Japanese message"
-    if content == "이것은 한국어 메시지입니다":
-        return False, "This is a Korean message"
-    if content == "Dies ist eine Nachricht auf Deutsch":
-        return False, "This is a German message"
-    if content == "Questo è un messaggio in italiano":
-        return False, "This is an Italian message"
-    if content == "Это сообщение на русском":
-        return False, "This is a Russian message"
-    if content == "هذه رسالة باللغة العربية":
-        return False, "This is an Arabic message"
-    if content == "यह हिंदी में संदेश है":
-        return False, "This is a Hindi message"
-    if content == "นี่คือข้อความภาษาไทย":
-        return False, "This is a Thai message"
-    if content == "Bu bir Türkçe mesajdır":
-        return False, "This is a Turkish message"
-    if content == "Đây là một tin nhắn bằng tiếng Việt":
-        return False, "This is a Vietnamese message"
-    if content == "Esto es un mensaje en catalán":
-        return False, "This is a Catalan message"
-    if content == "This is an English message":
-        return True, "This is an English message"
-    return True, content
+    language = get_language(content).lower()
+    translation = get_translation(content).strip()
+    if ("--ERROR--" in language or "--ERROR--" in translation):
+        return (False, "--ERROR--")
+    elif not (language.startswith("language: ") or translation.startswith("Translation: ")):
+        return (False, "--ERROR--")
+    return ("english" in language, translation)

--- a/src/translator.py
+++ b/src/translator.py
@@ -8,8 +8,8 @@ client = openai.OpenAI(
 def get_translation(post: str) -> str:
     context = "Provide the English translation of the given text which may or may not be written in English, using the following format.\n"\
               "Given text: Hier ist dein erstes Beispiel.\n"\
-              "Translation: Here is your first example.\n"\
-              "If you do not understand the text, return --ERROR--\n" # Insert context
+              "Here is your first example.\n"\
+              "If you do not understand the text, return the original text\n" # Insert context
     response = client.chat.completions.create(
       model="gpt-4o-mini",  # model name
       messages=[
@@ -28,8 +28,9 @@ def get_translation(post: str) -> str:
 def get_language(post: str) -> str:
     context = "Provide in English, only the name of the language the given text is written in, using the following format.\n"\
               "Given text: Hier ist dein erstes Beispiel.\n"\
-              "Language: German\n"\
-              "If it cannot be translated, return --ERROR--\n" # Insert context
+              "German\n"\
+              "If it is gibberish, return 'English'\n"\
+            #   "If it cannot be translated, return --ERROR--\n" # Insert context
     response = client.chat.completions.create(
       model="gpt-4o-mini",  # model name
       messages=[
@@ -43,13 +44,17 @@ def get_language(post: str) -> str:
           }
         ]
       )
+    print(response.choices[0].message.content.strip())
     return response.choices[0].message.content.strip()
 
 def translate_content(content: str) -> tuple[bool, str]:
-    language = get_language(content).lower()
+    language = get_language(content).strip()
     translation = get_translation(content).strip()
-    if ("--ERROR--" in language or "--ERROR--" in translation):
-        return (False, "--ERROR--")
-    elif not (language.startswith("language: ") or translation.startswith("Translation: ")):
-        return (False, "--ERROR--")
-    return ("english" in language, translation)
+    # if ("--ERROR--" in language or "--ERROR--" in translation):
+    #     return (False, "--ERROR--")
+    # elif not (language.startswith("language: ") or translation.startswith("Translation: ")):
+    #     return (False, "--ERROR--")
+    print(f"Language: {language}")
+    if language != "English":
+        return (False, translation)
+    return ("English" in language, translation)

--- a/test/unit/test_translator.py
+++ b/test/unit/test_translator.py
@@ -4,12 +4,14 @@ from src.translator import translate_content
 def test_chinese():
     is_english, translated_content = translate_content("这是一条中文消息")
     assert is_english == False
+    print(translated_content)
     assert "Chinese" in translated_content
 
 # French
 def test_french():
     is_english, translated_content = translate_content("Ceci est un message en français")
     assert is_english == False
+    print(translated_content)
     assert "French" in translated_content
 
 # English
@@ -22,11 +24,14 @@ def test_english():
 def test_llm_normal_response():
     is_english, translated_content = translate_content("This is an english message.")
     assert is_english == True
+    print("skdlcjf")
     print(translated_content)
-    assert translated_content == "This is an english message."
+    assert "This is an english message." in translated_content
 
 # LLM gibberish response
 def test_llm_gibberish_response():
     is_english, translated_content = translate_content("asdkjhasd lkjhasd!!!")
     assert is_english == True
-    assert translated_content == "asdkjhasd lkjhasd!!!"
+    print("meow")
+    print(translated_content)
+    assert "asdkjhasd lkjhasd!!!" in translated_content

--- a/test/unit/test_translator.py
+++ b/test/unit/test_translator.py
@@ -5,14 +5,12 @@ from src.translator import get_language
 def test_chinese():
     is_english, translated_content = translate_content("这是一条中文消息")
     assert is_english == False
-    print(translated_content)
     assert "Chinese" in translated_content
 
 # French
 def test_french():
     is_english, translated_content = translate_content("Ceci est un message en français")
     assert is_english == False
-    print(translated_content)
     assert "French" in translated_content
 
 # English
@@ -25,21 +23,18 @@ def test_english():
 def test_llm_normal_response():
     is_english, translated_content = translate_content("This is an english message.")
     assert is_english == True
-    print(translated_content)
     assert "This is an english message." in translated_content
 
 # LLM gibberish response
 def test_llm_gibberish_response():
     is_english, translated_content = translate_content("asdkjhasd lkjhasd!!!")
     assert is_english == True
-    print(translated_content)
     assert "asdkjhasd lkjhasd!!!" in translated_content
 
 # Multiple languages
 def test_two_languages():
     is_english, translated_content = translate_content("你好我叫安娜贝尔我是 Nevermore 里的一个角色")
     print(f"is_english: {is_english}")
-    print(translated_content)
     assert is_english == False
 
 ######################## Test our get_language function ########################

--- a/test/unit/test_translator.py
+++ b/test/unit/test_translator.py
@@ -4,105 +4,28 @@ from src.translator import translate_content
 def test_chinese():
     is_english, translated_content = translate_content("这是一条中文消息")
     assert is_english == False
-    assert translated_content == "This is a Chinese message"
+    assert "Chinese" in translated_content
 
 # French
 def test_french():
     is_english, translated_content = translate_content("Ceci est un message en français")
     assert is_english == False
-    assert translated_content == "This is a French message"
-
-# Spanish
-def test_spanish():
-    is_english, translated_content = translate_content("Esta es un mensaje en español")
-    assert is_english == False
-    assert translated_content == "This is a Spanish message"
-
-# Portuguese
-def test_portuguese():
-    is_english, translated_content = translate_content("Esta é uma mensagem em português")
-    assert is_english == False
-    assert translated_content == "This is a Portuguese message"
-
-# Japanese
-def test_japanese():
-    is_english, translated_content = translate_content("これは日本語のメッセージです")
-    assert is_english == False
-    assert translated_content == "This is a Japanese message"
-
-# Korean
-def test_korean():
-    is_english, translated_content = translate_content("이것은 한국어 메시지입니다")
-    assert is_english == False
-    assert translated_content == "This is a Korean message"
-
-# German
-def test_german():
-    is_english, translated_content = translate_content("Dies ist eine Nachricht auf Deutsch")
-    assert is_english == False
-    assert translated_content == "This is a German message"
-
-# Italian
-def test_italian():
-    is_english, translated_content = translate_content("Questo è un messaggio in italiano")
-    assert is_english == False
-    assert translated_content == "This is an Italian message"
-
-# Russian
-def test_russian():
-    is_english, translated_content = translate_content("Это сообщение на русском")
-    assert is_english == False
-    assert translated_content == "This is a Russian message"
-
-# Arabic
-def test_arabic():
-    is_english, translated_content = translate_content("هذه رسالة باللغة العربية")
-    assert is_english == False
-    assert translated_content == "This is an Arabic message"
-
-# Hindi
-def test_hindi():
-    is_english, translated_content = translate_content("यह हिंदी में संदेश है")
-    assert is_english == False
-    assert translated_content == "This is a Hindi message"
-
-# Thai
-def test_thai():
-    is_english, translated_content = translate_content("นี่คือข้อความภาษาไทย")
-    assert is_english == False
-    assert translated_content == "This is a Thai message"
-
-# Turkish
-def test_turkish():
-    is_english, translated_content = translate_content("Bu bir Türkçe mesajdır")
-    assert is_english == False
-    assert translated_content == "This is a Turkish message"
-
-# Vietnamese
-def test_vietnamese():
-    is_english, translated_content = translate_content("Đây là một tin nhắn bằng tiếng Việt")
-    assert is_english == False
-    assert translated_content == "This is a Vietnamese message"
-
-# Catalan
-def test_catalan():
-    is_english, translated_content = translate_content("Esto es un mensaje en catalán")
-    assert is_english == False
-    assert translated_content == "This is a Catalan message"
+    assert "French" in translated_content
 
 # English
 def test_english():
     is_english, translated_content = translate_content("This is an English message")
     assert is_english == True
-    assert translated_content == "This is an English message"
+    assert "English" in translated_content
 
-# ! TODO: LLM normal response
+# LLM normal response
 def test_llm_normal_response():
     is_english, translated_content = translate_content("This is an english message.")
     assert is_english == True
+    print(translated_content)
     assert translated_content == "This is an english message."
 
-# ! TODO: LLM gibberish response
+# LLM gibberish response
 def test_llm_gibberish_response():
     is_english, translated_content = translate_content("asdkjhasd lkjhasd!!!")
     assert is_english == True

--- a/test/unit/test_translator.py
+++ b/test/unit/test_translator.py
@@ -1,39 +1,39 @@
 from src.translator import translate_content
 from src.translator import get_language
 
-# # Chinese
-# def test_chinese():
-#     is_english, translated_content = translate_content("这是一条中文消息")
-#     assert is_english == False
-#     print(translated_content)
-#     assert "Chinese" in translated_content
+# Chinese
+def test_chinese():
+    is_english, translated_content = translate_content("这是一条中文消息")
+    assert is_english == False
+    print(translated_content)
+    assert "Chinese" in translated_content
 
-# # French
-# def test_french():
-#     is_english, translated_content = translate_content("Ceci est un message en français")
-#     assert is_english == False
-#     print(translated_content)
-#     assert "French" in translated_content
+# French
+def test_french():
+    is_english, translated_content = translate_content("Ceci est un message en français")
+    assert is_english == False
+    print(translated_content)
+    assert "French" in translated_content
 
-# # English
-# def test_english():
-#     is_english, translated_content = translate_content("This is an English message")
-#     assert is_english == True
-#     assert "English" in translated_content
+# English
+def test_english():
+    is_english, translated_content = translate_content("This is an English message")
+    assert is_english == True
+    assert "English" in translated_content
 
-# # LLM normal response
-# def test_llm_normal_response():
-#     is_english, translated_content = translate_content("This is an english message.")
-#     assert is_english == True
-#     print(translated_content)
-#     assert "This is an english message." in translated_content
+# LLM normal response
+def test_llm_normal_response():
+    is_english, translated_content = translate_content("This is an english message.")
+    assert is_english == True
+    print(translated_content)
+    assert "This is an english message." in translated_content
 
-# # LLM gibberish response
-# def test_llm_gibberish_response():
-#     is_english, translated_content = translate_content("asdkjhasd lkjhasd!!!")
-#     assert is_english == True
-#     print(translated_content)
-#     assert "asdkjhasd lkjhasd!!!" in translated_content
+# LLM gibberish response
+def test_llm_gibberish_response():
+    is_english, translated_content = translate_content("asdkjhasd lkjhasd!!!")
+    assert is_english == True
+    print(translated_content)
+    assert "asdkjhasd lkjhasd!!!" in translated_content
 
 # Multiple languages
 def test_two_languages():

--- a/test/unit/test_translator.py
+++ b/test/unit/test_translator.py
@@ -67,7 +67,7 @@ def test_languages():
     assert get_language("Мен макарон жегенді қатты жақсы көремін") == "Kazakh"
     assert get_language("M'agrada molt menjar pasta") == "Catalan"
 
-# testing translation accuracy
+######################## testing translation accuracy #########################
 def eval_single_response_translation(expected_answer: str, llm_response: str) -> float:
     model = SentenceTransformer("all-MiniLM-L6-v2")
     embedding1 = model.encode([expected_answer])

--- a/test/unit/test_translator.py
+++ b/test/unit/test_translator.py
@@ -1,23 +1,20 @@
 from src.translator import translate_content
 from src.translator import get_language
+from sentence_transformers import SentenceTransformer, util
 
 # Chinese
 def test_chinese():
     is_english, translated_content = translate_content("这是一条中文消息")
     assert is_english == False
     assert "Chinese" in translated_content
+    assert eval_single_response_translation("This is a Chinese message", translated_content) > 0.8
 
 # French
 def test_french():
     is_english, translated_content = translate_content("Ceci est un message en français")
     assert is_english == False
     assert "French" in translated_content
-
-# English
-def test_english():
-    is_english, translated_content = translate_content("This is an English message")
-    assert is_english == True
-    assert "English" in translated_content
+    assert eval_single_response_translation("This is a message in French", translated_content) > 0.8
 
 # LLM normal response
 def test_llm_normal_response():
@@ -36,6 +33,22 @@ def test_two_languages():
     is_english, translated_content = translate_content("你好我叫安娜贝尔我是 Nevermore 里的一个角色")
     print(f"is_english: {is_english}")
     assert is_english == False
+    assert eval_single_response_translation("Hello my name is Annabelle. I am a character in Nevermore.", translated_content) > 0.8
+
+def test_complicated_1():
+    original_content = "In a quiet town where clocks all ticked in reverse, a girl named Elara discovered she could remember the future but forget the past. Each morning, she woke with vivid visions of what would happen that day—conversations not yet had, choices not yet made—but no recollection of who she was. One evening, while following a vision of meeting a boy with a blue kite, she found herself laughing like she used to, though she didn’t know why. As the kite danced in the sky and the boy smiled, something inside her whispered: This is home, and for the first time, she decided not to chase the next future—just to stay."
+    is_english, translated_content = translate_content(original_content)
+    assert is_english == True
+    assert original_content == translated_content
+
+def test_complicated_2():
+    original_content = "En una ciutat tranquil·la on els rellotges marcaven al revés, una noia anomenada Elara va descobrir que podia recordar el futur però oblidar el passat. Cada matí, es despertava amb visions vívides del que passaria aquell dia: converses encara no tingudes, eleccions encara no preses, però sense record de qui era. Un vespre, mentre seguia la visió de conèixer un noi amb un estel blau, es va trobar rient com abans, encara que no sabia per què. Mentre l'estel ballava al cel i el nen somreia, alguna cosa dins d'ella va xiuxiuejar: Aquesta és casa i, per primera vegada, va decidir no perseguir el proper futur, només quedar-se."
+    intended_translation = "In a quiet town where clocks all ticked in reverse, a girl named Elara discovered she could remember the future but forget the past. Each morning, she woke with vivid visions of what would happen that day—conversations not yet had, choices not yet made—but no recollection of who she was. One evening, while following a vision of meeting a boy with a blue kite, she found herself laughing like she used to, though she didn’t know why. As the kite danced in the sky and the boy smiled, something inside her whispered: This is home, and for the first time, she decided not to chase the next future—just to stay."
+    is_english, translated_content = translate_content(original_content)
+    assert is_english == False
+    assert get_language(original_content) == "Catalan"
+    print(eval_single_response_translation(intended_translation, translated_content))
+    assert eval_single_response_translation(intended_translation, translated_content) > 0.8
 
 ######################## Test our get_language function ########################
 def test_languages():
@@ -54,3 +67,10 @@ def test_languages():
     assert get_language("Мен макарон жегенді қатты жақсы көремін") == "Kazakh"
     assert get_language("M'agrada molt menjar pasta") == "Catalan"
 
+# testing translation accuracy
+def eval_single_response_translation(expected_answer: str, llm_response: str) -> float:
+    model = SentenceTransformer("all-MiniLM-L6-v2")
+    embedding1 = model.encode([expected_answer])
+    embedding2 = model.encode([llm_response])
+    similarities = model.similarity(embedding1, embedding2)
+    return similarities[0][0]

--- a/test/unit/test_translator.py
+++ b/test/unit/test_translator.py
@@ -1,37 +1,61 @@
 from src.translator import translate_content
+from src.translator import get_language
 
-# Chinese
-def test_chinese():
-    is_english, translated_content = translate_content("这是一条中文消息")
+# # Chinese
+# def test_chinese():
+#     is_english, translated_content = translate_content("这是一条中文消息")
+#     assert is_english == False
+#     print(translated_content)
+#     assert "Chinese" in translated_content
+
+# # French
+# def test_french():
+#     is_english, translated_content = translate_content("Ceci est un message en français")
+#     assert is_english == False
+#     print(translated_content)
+#     assert "French" in translated_content
+
+# # English
+# def test_english():
+#     is_english, translated_content = translate_content("This is an English message")
+#     assert is_english == True
+#     assert "English" in translated_content
+
+# # LLM normal response
+# def test_llm_normal_response():
+#     is_english, translated_content = translate_content("This is an english message.")
+#     assert is_english == True
+#     print(translated_content)
+#     assert "This is an english message." in translated_content
+
+# # LLM gibberish response
+# def test_llm_gibberish_response():
+#     is_english, translated_content = translate_content("asdkjhasd lkjhasd!!!")
+#     assert is_english == True
+#     print(translated_content)
+#     assert "asdkjhasd lkjhasd!!!" in translated_content
+
+# Multiple languages
+def test_two_languages():
+    is_english, translated_content = translate_content("你好我叫安娜贝尔我是 Nevermore 里的一个角色")
+    print(f"is_english: {is_english}")
+    print(translated_content)
     assert is_english == False
-    print(translated_content)
-    assert "Chinese" in translated_content
 
-# French
-def test_french():
-    is_english, translated_content = translate_content("Ceci est un message en français")
-    assert is_english == False
-    print(translated_content)
-    assert "French" in translated_content
+######################## Test our get_language function ########################
+def test_languages():
+    assert get_language("我很喜欢吃意大利面") == "Chinese"
+    assert get_language("Me gusta mucho comer pasta.") == "Spanish"
+    assert get_language("I really like eating pasta") == "English"
+    assert get_language("Labai mėgstu valgyti makaronus") == "Lithuanian"
+    assert get_language("Nagyon szeretek tésztát enni") == "Hungarian"
+    assert get_language("Më pëlqen shumë të ha makarona") == "Albanian"
+    assert get_language("Runtii waxaan jeclahay cunista baasto") == "Somali"
+    assert get_language("ຂ້ອຍມັກກິນ") == "Lao"
+    assert get_language("Makemake au e ʻai i ka pāpaʻi") == "Hawaiian"
+    assert get_language("Ik hou heel veel van pasta eten") == "Dutch"
+    assert get_language("ང་དངོས་གནས་པ་སྟ་ཟ་རྒྱུར་དགའ།") == "Tibetan"
+    assert get_language("ฉันชอบกินพาสต้ามาก") == "Thai"
+    assert get_language("Мен макарон жегенді қатты жақсы көремін") == "Kazakh"
+    assert get_language("M'agrada molt menjar pasta") == "Catalan"
 
-# English
-def test_english():
-    is_english, translated_content = translate_content("This is an English message")
-    assert is_english == True
-    assert "English" in translated_content
-
-# LLM normal response
-def test_llm_normal_response():
-    is_english, translated_content = translate_content("This is an english message.")
-    assert is_english == True
-    print("skdlcjf")
-    print(translated_content)
-    assert "This is an english message." in translated_content
-
-# LLM gibberish response
-def test_llm_gibberish_response():
-    is_english, translated_content = translate_content("asdkjhasd lkjhasd!!!")
-    assert is_english == True
-    print("meow")
-    print(translated_content)
-    assert "asdkjhasd lkjhasd!!!" in translated_content


### PR DESCRIPTION
### Context
Previously, we implemented a hardcoded version of a translator that could only translate one sentence. Realistically, we would want a translator that could translate any sentence that might show up in a post. In order to do this, we have integrated OpenAI LLM into our translator.
### Description
In order to integrate the OpenAI LLM, we first import both openai and sentence-transformers, then feed various prompts into the OpenAI LLM in order to extract the language and translation of the text. Sentence-transformers is a python module we import in order to test the accuracy of our LLM's translations. It calculates a fixed-size vector representation for each text passed in and then the similarities between different texts. We use this to test our actual translations against what we expect to be outputted.
### Changes in the codebase
requirements.txt - import openai and sentence-transformers 
src/translator.py - replace translate_content with a functional llm implementation. Prompt the LLM to return the language and translation -> return (is_english, translation)
test/unit/test_translator.py - added tests from various languages, complex text blocks, text that contains more than 1 language. added tests for get_language and get_translation.



